### PR TITLE
app/ToolbarLayout: fix selectMode subtitle visiblity in landscape

### DIFF
--- a/yanndroid/oneui/src/main/java/de/dlyt/yanndroid/oneui/layout/ToolbarLayout.java
+++ b/yanndroid/oneui/src/main/java/de/dlyt/yanndroid/oneui/layout/ToolbarLayout.java
@@ -556,8 +556,7 @@ public class ToolbarLayout extends LinearLayout {
                 collapsingToolbarLayout.setSubtitle(null);
             }
             collapsedSubTitleView.setText(null);
-
-            updateCollapsedSubtitleVisibility();
+            collapsedSubTitleView.setVisibility(GONE);
         }
 
         if (selectModeBottomMenu != null) {
@@ -593,8 +592,7 @@ public class ToolbarLayout extends LinearLayout {
                 collapsingToolbarLayout.setSubtitle(null);
             }
             collapsedSubTitleView.setText(null);
-
-            updateCollapsedSubtitleVisibility();
+            collapsedSubTitleView.setVisibility(GONE);
         }
 
         main_toolbar.setVisibility(GONE);


### PR DESCRIPTION
Signed-off-by: BlackMesa123 <giangrecosalvo9@gmail.com>